### PR TITLE
Fix tempfile read sharing violation (Permission Denied) on Windows

### DIFF
--- a/py010parser/__init__.py
+++ b/py010parser/__init__.py
@@ -11,6 +11,7 @@ __all__ = ['c_lexer', 'c_parser', 'c_ast']
 __version__ = '0.1.10'
 
 
+import os
 import subprocess
 import tempfile
 
@@ -114,10 +115,14 @@ def parse_string(text, parser=None, filename="<string>", optimize=True, predefin
         use_cpp=True, cpp_path='cpp', cpp_args='', keep_scopes=False):
     
     if use_cpp:
-        with tempfile.NamedTemporaryFile("w") as f:
+        tempfile_path = ''
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
             f.write(text)
             f.flush()
-            text = preprocess_file(f.name, cpp_path, cpp_args)
+            tempfile_path = f.name
+
+        text = preprocess_file(tempfile_path, cpp_path, cpp_args)
+        os.unlink(tempfile_path)
 
     if parser is None:
         parser = CParser(


### PR DESCRIPTION
When trying to compile a template on Windows (using ```cpp.exe``` from MinGW), ```parse_file``` opens a ```NamedTempFile``` and passes the filename to the parsing function, which in turn executes ```cpp.exe``` with this filename. On windows, leaving a ```NamedTempFile``` open locks the file handle, so when ```cpp.exe``` tries to open it for reading, it fails with "Permission denied".

I fixed the bug by simply opening the file with ```delete=False```, closing it, then deleting the manually after the parsing takes place.